### PR TITLE
fix (CashRegisters): Fixed Cash Registers not being able to be robbed.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -22,7 +22,6 @@ Citizen.CreateThread(function()
         end
     end
 end)
-
 Citizen.CreateThread(function()
     Citizen.Wait(1000)
     setupRegister()
@@ -33,13 +32,12 @@ Citizen.CreateThread(function()
         local inRange = false
         for k, v in pairs(Config.Registers) do
             local dist = #(pos - Config.Registers[k][1].xyz)
-
             if dist <= 1 and Config.Registers[k].robbed then
                 inRange = true
                 DrawText3Ds(Config.Registers[k][1].xyz, 'The Cash Register Is Empty')
             end
         end
-        if not inRange then 
+        if not inRange then
             Citizen.Wait(2000)
         end
         Citizen.Wait(3)
@@ -47,7 +45,7 @@ Citizen.CreateThread(function()
 end)
 
 Citizen.CreateThread(function()
-    while true do 
+    while true do
         Citizen.Wait(1)
         local inRange = false
         if QBCore ~= nil then
@@ -85,7 +83,7 @@ Citizen.CreateThread(function()
                                         local street1 = GetStreetNameFromHashKey(s1)
                                         local street2 = GetStreetNameFromHashKey(s2)
                                         local streetLabel = street1
-                                        if street2 ~= nil then 
+                                        if street2 ~= nil then
                                             streetLabel = streetLabel .. " " .. street2
                                         end
                                         TriggerServerEvent("qb-storerobbery:server:callCops", "safe", currentSafe, streetLabel, pos)
@@ -152,42 +150,33 @@ AddEventHandler('lockpicks:UseLockpick', function(isAdvanced)
                         local street1 = GetStreetNameFromHashKey(s1)
                         local street2 = GetStreetNameFromHashKey(s2)
                         local streetLabel = street1
-                        if street2 ~= nil then 
+                        if street2 ~= nil then
                             streetLabel = streetLabel .. " " .. street2
                         end
-                        print('1')
                         TriggerServerEvent("qb-storerobbery:server:callCops", "cashier", currentRegister, streetLabel, pos)
                         copsCalled = true
                     end
                 else
-                    -- print("YES")
-                    
-                    -- QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasitem)
-                    --     print(hasitem)
-                    --     if result then
-                            lockpick(true)
-                            currentRegister = k
-                            if not IsWearingHandshoes() then
-                                TriggerServerEvent("evidence:server:CreateFingerDrop", pos)
-                            end
-                            if not copsCalled then
-                                print('alarm')
-                                local s1, s2 = Citizen.InvokeNative(0x2EB41072B4C1E4C0, pos.x, pos.y, pos.z, Citizen.PointerValueInt(), Citizen.PointerValueInt())
-                                local street1 = GetStreetNameFromHashKey(s1)
-                                local street2 = GetStreetNameFromHashKey(s2)
-                                local streetLabel = street1
-                                if street2 ~= nil then 
-                                    streetLabel = streetLabel .. " " .. street2
-                                end
-                                TriggerServerEvent("qb-storerobbery:server:callCops", "cashier", currentRegister, streetLabel, pos)
-                                copsCalled = true
-                            end
-                    --     else
-                    --         QBCore.Functions.Notify("It Looks Like You Are Missing A ToolKit", "error")
-                    --     end
-                    -- end, "screwdriverset")
+
+                    lockpick(true)
+                    currentRegister = k
+                    if not IsWearingHandshoes() then
+                        TriggerServerEvent("evidence:server:CreateFingerDrop", pos)
+                    end
+                    if not copsCalled then
+                        local s1, s2 = Citizen.InvokeNative(0x2EB41072B4C1E4C0, pos.x, pos.y, pos.z, Citizen.PointerValueInt(), Citizen.PointerValueInt())
+                        local street1 = GetStreetNameFromHashKey(s1)
+                        local street2 = GetStreetNameFromHashKey(s2)
+                        local streetLabel = street1
+                        if street2 ~= nil then
+                            streetLabel = streetLabel .. " " .. street2
+                        end
+                        TriggerServerEvent("qb-storerobbery:server:callCops", "cashier", currentRegister, streetLabel, pos)
+                        copsCalled = true
+                    end
+
                 end
-                
+
             else
                 QBCore.Functions.Notify("Not Enough Police (2 Required)", "error")
             end
@@ -199,7 +188,7 @@ function IsWearingHandshoes()
     local armIndex = GetPedDrawableVariation(PlayerPedId(), 3)
     local model = GetEntityModel(PlayerPedId())
     local retval = true
-    
+
     if model == GetHashKey("mp_m_freemode_01") then
         if Config.MaleNoHandshoes[armIndex] ~= nil and Config.MaleNoHandshoes[armIndex] then
             retval = false
@@ -290,7 +279,7 @@ RegisterNUICallback('success', function()
         }, {}, {}, function() -- Done
             openingDoor = false
             ClearPedTasks(PlayerPedId())
-            TriggerServerEvent('qb-storerobbery:server:takeMoney', currentRegister, true)            
+            TriggerServerEvent('qb-storerobbery:server:takeMoney', currentRegister, true)
             currentRegister = 0
         end, function() -- Cancel
             openingDoor = false
@@ -430,12 +419,16 @@ RegisterNUICallback('TryCombination', function(data, cb)
 end)
 
 RegisterNetEvent('qb-storerobbery:client:setRegisterStatus')
-AddEventHandler('qb-storerobbery:client:setRegisterStatus', function(batch, bool)
-    for k, v in pairs(batch) do
-        Config.Registers[k].robbed = bool
+AddEventHandler('qb-storerobbery:client:setRegisterStatus', function(batch, val)
+    -- Has to be a better way maybe like adding a unique id to identify the register
+    if(type(batch) ~= "table") then
+        Config.Registers[batch] = val
+    else
+        for k, v in pairs(batch) do
+            Config.Registers[k] = batch[k]
+        end
     end
 end)
-
 
 RegisterNetEvent('qb-storerobbery:client:setSafeStatus')
 AddEventHandler('qb-storerobbery:client:setSafeStatus', function(safe, bool)

--- a/server/main.lua
+++ b/server/main.lua
@@ -4,7 +4,7 @@ local cashB = 450				--<< how much maximum you can get from a robbery
 
 
 Citizen.CreateThread(function()
-    while true do 
+    while true do
         SafeCodes = {
             [1] = math.random(1000, 9999),
             [2] = {math.random(1, 149), math.random(150.0, 359.0), math.random(1, 149), math.random(150.0, 359.0), math.random(1, 149)},
@@ -61,9 +61,9 @@ end)
 
 RegisterServerEvent('qb-storerobbery:server:setRegisterStatus')
 AddEventHandler('qb-storerobbery:server:setRegisterStatus', function(register)
-    TriggerClientEvent('qb-storerobbery:client:setRegisterStatus', -1, register, true)
     Config.Registers[register].robbed   = true
     Config.Registers[register].time     = Config.resetTime
+    TriggerClientEvent('qb-storerobbery:client:setRegisterStatus', -1, register, Config.Registers[register])
 end)
 
 RegisterServerEvent('qb-storerobbery:server:setSafeStatus')
@@ -120,16 +120,25 @@ end)
 Citizen.CreateThread(function()
     while true do
         local toSend = {}
-        for k, v in pairs(Config.Registers) do
+        for k, v in ipairs(Config.Registers) do
+
             if Config.Registers[k].time > 0 and (Config.Registers[k].time - Config.tickInterval) >= 0 then
                 Config.Registers[k].time = Config.Registers[k].time - Config.tickInterval
             else
-                Config.Registers[k].time = 0
-                Config.Registers[k].robbed = false
-                table.insert(toSend, k)
+                if Config.Registers[k].robbed then
+                    Config.Registers[k].time = 0
+                    Config.Registers[k].robbed = false
+
+                    table.insert(toSend, Config.Registers[k])
+                end
             end
         end
-        TriggerClientEvent('qb-storerobbery:client:setRegisterStatus', -1, toSend, false)        
+
+        if #toSend > 0 then
+            --The false on the end of this is redundant
+            TriggerClientEvent('qb-storerobbery:client:setRegisterStatus', -1, toSend, false)
+        end
+
         Citizen.Wait(Config.tickInterval)
     end
 end)


### PR DESCRIPTION
I remove some backend commented-out comments.

- I fixed the timer-based setCashRegisterStatus as it was just sending an index rather than the object, not sure what it was trying to achieve by breaking it.

I've done some minor testing on a server. this way the timer depends on the backend rather than the front end. There may be a better way of handling the data-sync but I worked within the restraints of the resource :)