### PR TITLE
fix: set robbed status later to avoid false exploit kick

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local currentRegister   = 0
+local currentRegister = 0
 local currentSafe = 0
 local copsCalled = false
 local CurrentCops = 0
@@ -325,8 +325,8 @@ RegisterNetEvent('SafeCracker:EndMinigame', function(won)
             if currentSafe ~= 0 then
                 if not Config.Safes[currentSafe].robbed then
                     SetNuiFocus(false, false)
-                    TriggerServerEvent("qb-storerobbery:server:setSafeStatus", currentSafe)
                     TriggerServerEvent("qb-storerobbery:server:SafeReward", currentSafe)
+                    TriggerServerEvent("qb-storerobbery:server:setSafeStatus", currentSafe)
                     currentSafe = 0
                     takeAnim()
                 end
@@ -396,8 +396,8 @@ RegisterNUICallback('TryCombination', function(data, cb)
     QBCore.Functions.TriggerCallback('qb-storerobbery:server:isCombinationRight', function(combination)
         if tonumber(data.combination) ~= nil then
             if tonumber(data.combination) == combination then
-                TriggerServerEvent("qb-storerobbery:server:setSafeStatus", currentSafe)
                 TriggerServerEvent("qb-storerobbery:server:SafeReward", currentSafe)
+                TriggerServerEvent("qb-storerobbery:server:setSafeStatus", currentSafe)
                 SetNuiFocus(false, false)
                 SendNUIMessage({
                     action = "closeKeypad",


### PR DESCRIPTION
**Describe Pull request**
Fixes the issue of safes kicking you for exploit abuse when you're doing the right thing

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
