### PR TITLE
fix(locales): Move translation to correct table

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -5,13 +5,13 @@ local Translations = {
         demolish_vehicle = "You Are Not Allowed To Demolish Vehicles Now",
         process_canceled = "Process canceled..",
         you_broke_the_lock_pick = "You Broke The Lock Pick",
-        safe_code = "Safe Code: "
     },
     text = {
         the_cash_register_is_empty = "The Cash Register Is Empty",
         try_combination = "~g~E~w~ - Try Combination",
         safe_opened = "Safe Opened",
-        emptying_the_register= "Emptying The Register.."
+        emptying_the_register= "Emptying The Register..",
+        safe_code = "Safe Code: "
     },
     email = {
         shop_robbery = "10-31 | Shop Robbery",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -5,13 +5,13 @@ local Translations = {
         demolish_vehicle = "No está permitido derribar vehículos ahora",
         process_canceled = "Proceso cancelado..",
         you_broke_the_lock_pick = "Has roto la ganzúa",
-        safe_code = "Código de seguridad: "
     },
     text = {
         the_cash_register_is_empty = "La caja registradora está vacía",
         try_combination = "~g~E~w~ - Ingresa la combinación",
         safe_opened = "Caja abierta",
-        emptying_the_register= "Vaciando caja registradora.."
+        emptying_the_register= "Vaciando caja registradora..",
+        safe_code = "Código de seguridad: "
     },
     email = {
         shop_robbery = "10-31 | Robo en progreso en Tienda",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -4,13 +4,13 @@ local Translations = {
         not_driver = "Vous n'êtes pas le conducteur",
         process_canceled = "Annulé..",
         you_broke_the_lock_pick = "Vous avez cassé l'outil de crochetage",
-        safe_code = "Code du Coffre-fort: "
     },
     text = {
         the_cash_register_is_empty = "La caisse est vide",
         try_combination = "~g~E~w~ - Essayer la combinaison",
         safe_opened = "Coffre-fort ouvert",
-        emptying_the_register= "Vide la caisse.."
+        emptying_the_register= "Vide la caisse..",
+        safe_code = "Code du Coffre-fort: "
     },
     email = {
         shop_robbery = "10-31 | Braquage de superette",


### PR DESCRIPTION
**Describe Pull request**
The translation for `safe_code` was placed in the `error` table, but was being called with `text.safe_code`. This PR moves the translation to the `text` table.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
