### PR TITLE
Fix padlock sticky note

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,7 @@ Config.RegisterEarnings = math.random(Config.minEarn, Config.maxEarn)
 Config.MinimumStoreRobberyPolice = 2
 Config.resetTime = (60 * 1000) * 30
 Config.tickInterval = 1000
+Config.stickyNoteChance = 10 -- Percent chance to get the safe code from a cash register
 
 Config.Registers = {
     [1] = { vector3(-47.24, -1757.65, 29.53), robbed = false, time = 0, safeKey = 1, camId = 4 },

--- a/server/main.lua
+++ b/server/main.lua
@@ -57,9 +57,13 @@ RegisterNetEvent('qb-storerobbery:server:takeMoney', function(register, isDone)
                     label = Lang:t('text.safe_code') .. tostring(code)
                 }
             else
-                info = {
-                    label = Lang:t('text.safe_code') .. tostring(math.floor((code[1] % 360) / 3.60)) .. '-' .. tostring(math.floor((code[2] % 360) / 3.60)) .. '-' .. tostring(math.floor((code[3] % 360) / 3.60)) .. '-' .. tostring(math.floor((code[4] % 360) / 3.60)) .. '-' .. tostring(math.floor((code[5] % 360) / 3.60))
-                }
+                local label = Lang:t('text.safe_code') .. ' '
+
+                for i = 1, #code do
+                    label = label .. tostring(math.floor((code[i] % 360) / 3.60)) .. ' - '
+                end
+
+                info = {label = label:sub(1, -3)}
             end
             Player.Functions.AddItem('stickynote', 1, false, info)
             TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['stickynote'], 'add')

--- a/server/main.lua
+++ b/server/main.lua
@@ -50,7 +50,7 @@ RegisterNetEvent('qb-storerobbery:server:takeMoney', function(register, isDone)
         }
         Player.Functions.AddItem('markedbills', bags, false, info)
         TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['markedbills'], 'add')
-        if math.random(1, 100) <= 10 then
+        if math.random(1, 100) <= Config.stickyNoteChance then
             local code = SafeCodes[Config.Registers[register].safeKey]
             if Config.Safes[Config.Registers[register].safeKey].type == 'keypad' then
                 info = {


### PR DESCRIPTION
**Describe Pull request**
- Fixes #66 & issue w/ newer qb-inventory where the sticky note is not given at all.
- Adds configuration for sticky note chance

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
